### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Output filter plugin for modifying each event record
+# Output filter plugin for modifying each event record for [Fluentd](http://fluentd.org)
 
 Adding arbitary field to event record without custmizing existence plugin.
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
