### PR TITLE
Add config descriptions

### DIFF
--- a/lib/fluent/plugin/filter_record_modifier.rb
+++ b/lib/fluent/plugin/filter_record_modifier.rb
@@ -4,8 +4,19 @@ module Fluent
   class RecordModifierFilter < Filter
     Fluent::Plugin.register_filter('record_modifier', self)
 
-    config_param :char_encoding, :string, :default => nil
-    config_param :remove_keys, :string, :default => nil
+    config_param :char_encoding, :string, :default => nil,
+                 :desc => <<-DESC
+Fluentd including some plugins treats the logs as a BINARY by default to forward.
+But an user sometimes processes the logs depends on their requirements,
+e.g. handling char encoding correctly.
+In more detail, please refer this section:
+https://github.com/repeatedly/fluent-plugin-record-modifier#char_encoding.
+DESC
+    config_param :remove_keys, :string, :default => nil,
+                 :desc => <<-DESC
+The logs include needless record keys in some cases.
+You can remove it by using `remove_keys` parameter.
+DESC
 
     include Fluent::Mixin::ConfigPlaceholders
 

--- a/lib/fluent/plugin/out_record_modifier.rb
+++ b/lib/fluent/plugin/out_record_modifier.rb
@@ -4,9 +4,22 @@ module Fluent
   class RecordModifierOutput < Output
     Fluent::Plugin.register_output('record_modifier', self)
 
-    config_param :tag, :string
-    config_param :char_encoding, :string, :default => nil
-    config_param :remove_keys, :string, :default => nil
+    config_param :tag, :string,
+                 :desc => "The output record tag name."
+    config_param :char_encoding, :string, :default => nil,
+                 :desc => <<-DESC
+Fluentd including some plugins treats the logs as a BINARY by default to forward.
+But an user sometimes processes the logs depends on their requirements,
+e.g. handling char encoding correctly.
+In more detail, please refer this section:
+https://github.com/repeatedly/fluent-plugin-record-modifier#char_encoding.
+DESC
+
+    config_param :remove_keys, :string, :default => nil,
+                 :desc => <<-DESC
+The logs include needless record keys in some cases.
+You can remove it by using `remove_keys` parameter.
+DESC
 
     include SetTagKeyMixin
     include Fluent::Mixin::ConfigPlaceholders


### PR DESCRIPTION
With fluentd 0.12.19, config descriptions are shown like this:

```log
$ bundle exec fluentd --show-plugin-config output:record_modifier -p lib/fluent/plugin/
2016-01-15 17:48:57 +0900 [info]: Show config for output:record_modifier
2016-01-15 17:48:57 +0900 [info]: 
log_level: string: <nil> # Allows the user to set different levels of logging for each plugin.
tag: string: <nil> # The output record tag name.
char_encoding: string: <nil> # Fluentd including some plugins treats the logs as a BINARY by default to forward.
But an user sometimes processes the logs depends on their requirements,
e.g. handling char encoding correctly.
In more detail, please refer this section:
https://github.com/repeatedly/fluent-plugin-record-modifier#char_encoding.

remove_keys: string: <nil> # The logs include needless record keys in some cases.
You can remove it by using `remove_keys` parameter.

$ bundle exec fluentd --show-plugin-config filter:record_modifier -p lib/fluent/plugin/
2016-01-15 17:49:10 +0900 [info]: Show config for filter:record_modifier
2016-01-15 17:49:10 +0900 [info]: 
log_level: string: <nil> # Allows the user to set different levels of logging for each plugin.
char_encoding: string: <nil> # Fluentd including some plugins treats the logs as a BINARY by default to forward.
But an user sometimes processes the logs depends on their requirements,
e.g. handling char encoding correctly.
In more detail, please refer this section:
https://github.com/repeatedly/fluent-plugin-record-modifier#char_encoding.

remove_keys: string: <nil> # The logs include needless record keys in some cases.
You can remove it by using `remove_keys` parameter.
```