### PR TITLE
Set/convert encoding recursively

### DIFF
--- a/lib/fluent/plugin/filter_record_modifier.rb
+++ b/lib/fluent/plugin/filter_record_modifier.rb
@@ -83,21 +83,25 @@ module Fluent
 
     private
 
-    def set_encoding(record)
-      record.each_pair { |k, v|
-        if v.is_a?(String)
-          v.force_encoding(@from_enc)
-        end
-      }
+    def set_encoding(value)
+      if value.is_a?(String)
+        value.force_encoding(@from_enc)
+      elsif value.is_a?(Hash)
+        value.each_pair { |k, v| set_encoding(v) }
+      elsif value.is_a?(Array)
+        value.each { |v| set_encoding(v) }
+      end
     end
 
-    def convert_encoding(record)
-      record.each_pair { |k, v|
-        if v.is_a?(String)
-          v.force_encoding(@from_enc) if v.encoding == Encoding::BINARY
-          v.encode!(@to_enc, @from_enc, :invalid => :replace, :undef => :replace)
-        end
-      }
+    def convert_encoding(value)
+      if value.is_a?(String)
+        value.force_encoding(@from_enc) if value.encoding == Encoding::BINARY
+        value.encode!(@to_enc, @from_enc, :invalid => :replace, :undef => :replace)
+      elsif value.is_a?(Hash)
+        value.each_pair { |k, v| convert_encoding(v) }
+      elsif value.is_a?(Array)
+        value.each { |v| convert_encoding(v) }
+      end
     end
 
     class DynamicExpander

--- a/test/test_filter_record_modifier.rb
+++ b/test/test_filter_record_modifier.rb
@@ -62,12 +62,17 @@ class RecordModifierFilterTest < Test::Unit::TestCase
       char_encoding utf-8
     ]
 
-
     d.run do
       d.emit("k" => 'v'.force_encoding('BINARY'))
+      d.emit("k" => %w(v ビ).map{|v| v.force_encoding('BINARY')})
+      d.emit("k" => {"l" => 'ビ'.force_encoding('BINARY')})
     end
 
-    assert_equal [{"k" => 'v'.force_encoding('UTF-8')}], d.filtered_as_array.map { |e| e.last }
+    assert_equal [
+      {"k" => 'v'.force_encoding('UTF-8')},
+      {"k" => %w(v ビ).map{|v| v.force_encoding('UTF-8')}},
+      {"k" => {"l" => 'ビ'.force_encoding('UTF-8')}},
+    ], d.filtered_as_array.map { |e| e.last }
   end
 
   def test_convert_char_encoding
@@ -79,9 +84,15 @@ class RecordModifierFilterTest < Test::Unit::TestCase
 
     d.run do
       d.emit("k" => 'v'.force_encoding('utf-8'))
+      d.emit("k" => %w(v ビ).map{|v| v.force_encoding('utf-8')})
+      d.emit("k" => {"l" => 'ビ'.force_encoding('utf-8')})
     end
 
-    assert_equal [{"k" => 'v'.force_encoding('cp932')}], d.filtered_as_array.map { |e| e.last }
+    assert_equal [
+      {"k" => 'v'.force_encoding('cp932')},
+      {"k" => %w(v ビ).map{|v| v.encode!('cp932')}},
+      {"k" => {"l" => 'ビ'.encode!('cp932')}},
+    ], d.filtered_as_array.map { |e| e.last }
   end
 
   def test_remove_one_key


### PR DESCRIPTION
Current implementation does not perform recursive conversion, which leaves JSON-formatted event record untouched.
This fix solves the issue.