### PR TITLE
Migrate to v0.14 API

### DIFF
--- a/lib/fluent/plugin/filter_record_modifier.rb
+++ b/lib/fluent/plugin/filter_record_modifier.rb
@@ -83,31 +83,27 @@ DESC
       GC.start
     end
 
-    def filter_stream(tag, es)
-      new_es = MultiEventStream.new
+    def filter(tag, time, record)
       tag_parts = @has_tag_parts ? tag.split('.') : nil
 
-      es.each { |time, record|
-        @map.each_pair { |k, v|
-          record[k] = v.expand(tag, time, record, tag_parts)
-        }
-
-        if @remove_keys
-          @remove_keys.each { |v|
-            record.delete(v)
-          }
-        elsif @whitelist_keys
-          modified = {}
-          record.each do |k, v|
-            modified[k] = v if @whitelist_keys.include?(k)
-          end
-          record = modified
-        end
-
-        record = change_encoding(record) if @char_encoding
-        new_es.add(time, record)
+      @map.each_pair { |k, v|
+        record[k] = v.expand(tag, time, record, tag_parts)
       }
-      new_es
+
+      if @remove_keys
+        @remove_keys.each { |v|
+          record.delete(v)
+        }
+      elsif @whitelist_keys
+        modified = {}
+        record.each do |k, v|
+          modified[k] = v if @whitelist_keys.include?(k)
+        end
+        record = modified
+      end
+
+      record = change_encoding(record) if @char_encoding
+      record
     end
 
     private

--- a/lib/fluent/plugin/filter_record_modifier.rb
+++ b/lib/fluent/plugin/filter_record_modifier.rb
@@ -45,6 +45,7 @@ DESC
         end
       }
 
+      @to_enc = nil
       if @char_encoding
         from, to = @char_encoding.split(':', 2)
         @from_enc = Encoding.find(from)

--- a/lib/fluent/plugin/filter_record_modifier.rb
+++ b/lib/fluent/plugin/filter_record_modifier.rb
@@ -1,7 +1,7 @@
-require 'fluent/filter'
+require 'fluent/plugin/filter'
 
 module Fluent
-  class RecordModifierFilter < Filter
+  class Plugin::RecordModifierFilter < Plugin::Filter
     Fluent::Plugin.register_filter('record_modifier', self)
 
     config_param :char_encoding, :string, default: nil,

--- a/lib/fluent/plugin/filter_record_modifier.rb
+++ b/lib/fluent/plugin/filter_record_modifier.rb
@@ -187,5 +187,5 @@ DESC
         end
       end
     end
-  end if defined?(Filter)
+  end
 end

--- a/lib/fluent/plugin/out_record_modifier.rb
+++ b/lib/fluent/plugin/out_record_modifier.rb
@@ -48,6 +48,7 @@ DESC
         end
       }
 
+      @to_enc = nil
       if @char_encoding
         from, to = @char_encoding.split(':', 2)
         @from_enc = Encoding.find(from)

--- a/lib/fluent/plugin/out_record_modifier.rb
+++ b/lib/fluent/plugin/out_record_modifier.rb
@@ -4,7 +4,7 @@ module Fluent
   class Plugin::RecordModifierOutput < Plugin::Output
     Fluent::Plugin.register_output('record_modifier', self)
 
-    helpers :event_emitter
+    helpers :event_emitter, :compat_parameters
 
     config_param :tag, :string,
                  desc: "The output record tag name."
@@ -36,6 +36,7 @@ DESC
     BUILTIN_CONFIGURATIONS = %W(type tag include_tag_key tag_key char_encoding remove_keys whitelist_keys)
 
     def configure(conf)
+      compat_parameters_convert(conf, :buffer)
       super
 
       @map = {}

--- a/test/test_out_record_modifier.rb
+++ b/test/test_out_record_modifier.rb
@@ -1,4 +1,4 @@
-require 'fluent/test'
+require 'fluent/test/driver/output'
 require 'fluent/plugin/out_record_modifier'
 
 
@@ -19,7 +19,7 @@ class RecordModifierOutputTest < Test::Unit::TestCase
   !
 
   def create_driver(conf = CONFIG)
-    Fluent::Test::OutputTestDriver.new(Fluent::RecordModifierOutput, tag='test_tag').configure(conf, true)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::RecordModifierOutput).configure(conf)
   end
 
   def get_hostname
@@ -38,16 +38,17 @@ class RecordModifierOutputTest < Test::Unit::TestCase
   def test_format
     d = create_driver
 
-    d.run do
-      d.emit("a" => 1)
-      d.emit("a" => 2)
+    time = Time.now.to_i
+    d.run(default_tag: 'test_tag') do
+      d.feed(time, {"a" => 1})
+      d.feed(time, {"a" => 2})
     end
 
     mapped = {'gen_host' => get_hostname, 'foo' => 'bar', 'included_tag' => 'test_tag'}
     assert_equal [
       {"a" => 1}.merge(mapped),
       {"a" => 2}.merge(mapped),
-    ], d.records
+    ], d.events.map { |e| e.last }
   end
 
   def test_set_char_encoding
@@ -58,12 +59,12 @@ class RecordModifierOutputTest < Test::Unit::TestCase
       char_encoding utf-8
     ]
 
-
-    d.run do
-      d.emit("k" => 'v'.force_encoding('BINARY'))
+    time = Time.now.to_i
+    d.run(default_tag: 'test_tag') do
+      d.feed(time, {"k" => 'v'.force_encoding('BINARY')})
     end
 
-    assert_equal [{"k" => 'v'.force_encoding('UTF-8')}], d.records
+    assert_equal [{"k" => 'v'.force_encoding('UTF-8')}], d.events.map { |e| e.last }
   end
 
   def test_convert_char_encoding
@@ -74,11 +75,12 @@ class RecordModifierOutputTest < Test::Unit::TestCase
       char_encoding utf-8:cp932
     ]
 
-    d.run do
-      d.emit("k" => 'v'.force_encoding('utf-8'))
+    time = Time.now.to_i
+    d.run(default_tag: 'test_tag') do
+      d.feed("k" => 'v'.force_encoding('utf-8'))
     end
 
-    assert_equal [{"k" => 'v'.force_encoding('cp932')}], d.records
+    assert_equal [{"k" => 'v'.force_encoding('cp932')}], d.events.map { |e| e.last }
   end
 
   def test_remove_one_key
@@ -89,11 +91,12 @@ class RecordModifierOutputTest < Test::Unit::TestCase
       remove_keys k1
     ]
 
-    d.run do
-      d.emit("k1" => 'v', "k2" => 'v')
+    time = Time.now.to_i
+    d.run(default_tag: 'test_tag') do
+      d.feed(time, {"k1" => 'v', "k2" => 'v'})
     end
 
-    assert_equal [{"k2" => 'v'}], d.records
+    assert_equal [{"k2" => 'v'}], d.events.map { |e| e.last }
   end
 
   def test_remove_multiple_keys
@@ -104,11 +107,12 @@ class RecordModifierOutputTest < Test::Unit::TestCase
       remove_keys k1, k2, k3
     ]
 
-    d.run do
-      d.emit("k1" => 'v', "k2" => 'v', "k4" => 'v')
+    time = Time.now.to_i
+    d.run(default_tag: 'test_tag') do
+      d.feed(time, {"k1" => 'v', "k2" => 'v', "k4" => 'v'})
     end
 
-    assert_equal [{"k4" => 'v'}], d.records
+    assert_equal [{"k4" => 'v'}], d.events.map { |e| e.last }
   end
 
   def test_remove_non_whitelist_keys
@@ -119,10 +123,11 @@ class RecordModifierOutputTest < Test::Unit::TestCase
       whitelist_keys k1, k2, k3
     ]
 
-    d.run do
-      d.emit("k1" => 'v', "k2" => 'v', "k4" => 'v', "k5" => 'v')
+    time = Time.now.to_i
+    d.run(default_tag: 'test_tag') do
+      d.feed(time, {"k1" => 'v', "k2" => 'v', "k4" => 'v', "k5" => 'v'})
     end
 
-    assert_equal [{"k1" => 'v', "k2" => 'v'}], d.records
+    assert_equal [{"k1" => 'v', "k2" => 'v'}], d.events.map { |e| e.last }
   end
 end

--- a/test/test_out_record_modifier.rb
+++ b/test/test_out_record_modifier.rb
@@ -38,10 +38,9 @@ class RecordModifierOutputTest < Test::Unit::TestCase
   def test_format
     d = create_driver
 
-    time = Time.now.to_i
     d.run(default_tag: 'test_tag') do
-      d.feed(time, {"a" => 1})
-      d.feed(time, {"a" => 2})
+      d.feed({"a" => 1})
+      d.feed({"a" => 2})
     end
 
     mapped = {'gen_host' => get_hostname, 'foo' => 'bar', 'included_tag' => 'test_tag'}
@@ -59,9 +58,8 @@ class RecordModifierOutputTest < Test::Unit::TestCase
       char_encoding utf-8
     ]
 
-    time = Time.now.to_i
     d.run(default_tag: 'test_tag') do
-      d.feed(time, {"k" => 'v'.force_encoding('BINARY')})
+      d.feed({"k" => 'v'.force_encoding('BINARY')})
     end
 
     assert_equal [{"k" => 'v'.force_encoding('UTF-8')}], d.events.map { |e| e.last }
@@ -75,7 +73,6 @@ class RecordModifierOutputTest < Test::Unit::TestCase
       char_encoding utf-8:cp932
     ]
 
-    time = Time.now.to_i
     d.run(default_tag: 'test_tag') do
       d.feed("k" => 'v'.force_encoding('utf-8'))
     end
@@ -91,9 +88,8 @@ class RecordModifierOutputTest < Test::Unit::TestCase
       remove_keys k1
     ]
 
-    time = Time.now.to_i
     d.run(default_tag: 'test_tag') do
-      d.feed(time, {"k1" => 'v', "k2" => 'v'})
+      d.feed({"k1" => 'v', "k2" => 'v'})
     end
 
     assert_equal [{"k2" => 'v'}], d.events.map { |e| e.last }
@@ -107,9 +103,8 @@ class RecordModifierOutputTest < Test::Unit::TestCase
       remove_keys k1, k2, k3
     ]
 
-    time = Time.now.to_i
     d.run(default_tag: 'test_tag') do
-      d.feed(time, {"k1" => 'v', "k2" => 'v', "k4" => 'v'})
+      d.feed({"k1" => 'v', "k2" => 'v', "k4" => 'v'})
     end
 
     assert_equal [{"k4" => 'v'}], d.events.map { |e| e.last }
@@ -123,9 +118,8 @@ class RecordModifierOutputTest < Test::Unit::TestCase
       whitelist_keys k1, k2, k3
     ]
 
-    time = Time.now.to_i
     d.run(default_tag: 'test_tag') do
-      d.feed(time, {"k1" => 'v', "k2" => 'v', "k4" => 'v', "k5" => 'v'})
+      d.feed({"k1" => 'v', "k2" => 'v', "k4" => 'v', "k5" => 'v'})
     end
 
     assert_equal [{"k1" => 'v', "k2" => 'v'}], d.events.map { |e| e.last }


### PR DESCRIPTION
I've migrated this plugin to use v0.14 API.
This plugin seems to be required to high performance.
Should we benchmark to estimate impact from this change?
