### PR TITLE
Allow out_record_modifier to be used with multiple workers

### DIFF
--- a/lib/fluent/plugin/out_record_modifier.rb
+++ b/lib/fluent/plugin/out_record_modifier.rb
@@ -97,6 +97,10 @@ DESC
       GC.start
     end
 
+    def multi_workers_ready?
+      true
+    end
+
     def process(tag, es)
       tag_parts = @has_tag_parts ? tag.split('.') : nil
       if @tag_ex.param_value.nil?


### PR DESCRIPTION
```
$ cat fluent.conf
<system>
  workers 2
</system>

<match *>
  @type record_modifier
  tag a
</match>
```

Before:

```
$ bundle exec fluentd -c fluent.conf
2019-02-06 15:24:00 +0000 [info]: parsing config file is succeeded path="fluent.conf"
2019-02-06 15:24:00 +0000 [error]: config error file="fluent.conf" error_class=Fluent::ConfigError error="Plugin 'record_modifier' does not support multi workers configuration (Fluent::Plugin::RecordModifierOutput)"
```

After:

```
$ bundle exec fluentd -c fluent.conf
2019-02-06 15:25:28 +0000 [info]: parsing config file is succeeded path="fluent.conf"
2019-02-06 15:25:28 +0000 [info]: using configuration file: <ROOT>
...
```