### PR TITLE
Update the test fixtures and documentation for named capture references

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ If you want to replace specific value for keys you can use `replace` section.
     # your regexp
     expression /^(?<start>.+).{2}(?<end>.+)$/
     # replace string
-    replace \\k<start>ors\\k<end>
+    replace \k<start>ors\k<end>
   </replace>
   # replace key key2
   <replace>
@@ -173,7 +173,7 @@ If you want to replace specific value for keys you can use `replace` section.
     # your regexp
     expression /^(.{1}).{2}(.{1})$/
     # replace string
-    replace \\1ors\\2
+    replace \1ors\2
   </replace>
 </filter>
 ```

--- a/test/test_filter_record_modifier.rb
+++ b/test/test_filter_record_modifier.rb
@@ -145,18 +145,18 @@ class RecordModifierFilterTest < Test::Unit::TestCase
   end
 
   def test_replace_values
-    d = create_driver %[
+    d = create_driver <<'CONFIG'
         <replace>
           key k1
           expression /^(?<start>.+).{2}(?<end>.+)$/
-          replace \\k<start>ors\\k<end>
+          replace \k<start>ors\k<end>
         </replace>
         <replace>
           key k2
           expression /^(.{1}).{2}(.{1})$/
-          replace \\1ors\\2
+          replace \1ors\2
         </replace>
-    ]
+CONFIG
 
     d.run(default_tag: @tag) do
       d.feed("k1" => 'hoge', "k2" => 'hoge', "k3" => 'bar')
@@ -166,13 +166,13 @@ class RecordModifierFilterTest < Test::Unit::TestCase
   end
 
   def test_does_not_replace
-    d = create_driver %[
+    d = create_driver <<'CONFIG'
         <replace>
           key k1
           expression /^(?<start>.+).{2}(?<end>.+)$/
-          replace \\k<start>ors\\k<end>
+          replace \k<start>ors\k<end>
         </replace>
-    ]
+CONFIG
 
     d.run(default_tag: @tag) do
       d.feed("k1" => 'hog')


### PR DESCRIPTION
This PR:

* fixes the examples documented in the README.
* updates the test suite to avoid backslash escaping abiguity.

See each commit for the details.