### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ If you want to replace specific value for keys you can use `replace` section.
     # your regexp
     expression /^(?<start>.+).{2}(?<end>.+)$/
     # replace string
-    replace \\k<start>ors\\k<end>
+    replace \k<start>ors\k<end>
   </replace>
   # replace key key2
   <replace>
@@ -173,7 +173,7 @@ If you want to replace specific value for keys you can use `replace` section.
     # your regexp
     expression /^(.{1}).{2}(.{1})$/
     # replace string
-    replace \\1ors\\2
+    replace \1ors\2
   </replace>
 </filter>
 ```


### PR DESCRIPTION
Apparently, double backslashes do not work as documented for referencing regexp capture groups for `<replace>`. Single backslashes do.

The configuration from the current Readme version (with plugin v2.1.0):
```
<source>
    @type sample
    tag pattern
    sample [{"key1":"hoge", "key2":"hoge", "key3":"bar"}]
</source>

<filter pattern>
  @type record_modifier

  # replace key key1
  <replace>
    # your key name
    key key1
    # your regexp
    expression /^(?<start>.+).{2}(?<end>.+)$/
    # replace string
    replace \\k<start>ors\\k<end>
  </replace>
  # replace key key2
  <replace>
    # your key name
    key key2
    # your regexp
    expression /^(.{1}).{2}(.{1})$/
    # replace string
    replace \\1ors\\2
  </replace>
</filter>

<match pattern>
  @type stdout
</match>
```
Produces:
```
pattern: {"key1":"\\k<start>ors\\k<end>","key2":"\\1ors\\2","key3":"bar"}
```
---
The same configuration with single backslashes referencing the capture groups:
```
<source>
    @type sample
    tag pattern
    sample [{"key1":"hoge", "key2":"hoge", "key3":"bar"}]
</source>

<filter pattern>
  @type record_modifier

  # replace key key1
  <replace>
    # your key name
    key key1
    # your regexp
    expression /^(?<start>.+).{2}(?<end>.+)$/
    # replace string
    replace \k<start>ors\k<end>
  </replace>
  # replace key key2
  <replace>
    # your key name
    key key2
    # your regexp
    expression /^(.{1}).{2}(.{1})$/
    # replace string
    replace \1ors\2
  </replace>
</filter>

<match pattern>
  @type stdout
</match>
```
Produces:
```
pattern: {"key1":"horse","key2":"horse","key3":"bar"}
pattern: {"key1":"hoorse","key2":"horse","key3":"bar"}
pattern: {"key1":"hooorse","key2":"horse","key3":"bar"}
```