### PR TITLE
filter: remove_keys parameter supports nested delete. fix #44

### DIFF
--- a/fluent-plugin-record-modifier.gemspec
+++ b/fluent-plugin-record-modifier.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency "fluentd", [">= 1.0", "< 2"]
+  gem.add_dependency "fluentd", [">= 1.1", "< 2"]
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency("test-unit", ["~> 3.4.0"])
 end

--- a/test/test_filter_record_modifier.rb
+++ b/test/test_filter_record_modifier.rb
@@ -114,6 +114,18 @@ class RecordModifierFilterTest < Test::Unit::TestCase
     assert_equal [{"k4" => 'v'}], d.filtered.map { |e| e.last }
   end
 
+  def test_remove_nested_keys
+    d = create_driver %[
+      remove_keys k1, $.kubernetes.test
+    ]
+
+    d.run(default_tag: @tag) do
+      d.feed("k1" => 'v', "kubernetes" => {"test" => 'v', "prod" => 'v'}, "k2" => 'v')
+    end
+
+    assert_equal [{"kubernetes" => {"prod" => 'v'}, "k2" => 'v'}], d.filtered.map { |e| e.last }
+  end
+
   def test_remove_non_whitelist_keys
     d = create_driver %[
       <record>


### PR DESCRIPTION
Support nested delete via `record_accessor` helper.
In addition, change parameter type to `array` type. This change should not impact existing users.