### PR TITLE
Support use_nil for record values

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,7 +14,7 @@ jobs:
           - ubuntu-latest
         experimental: [false]
         include:
-          - ruby-version: head
+          - ruby: head
             os: ubuntu-latest
             experimental: true
 

--- a/lib/fluent/plugin/filter_record_modifier.rb
+++ b/lib/fluent/plugin/filter_record_modifier.rb
@@ -74,7 +74,7 @@ DESC
       conf.elements.select { |element| element.name == 'record' }.each do |element|
         element.each_pair do |k, v|
           element.has_key?(k) # to suppress unread configuration warning
-          @has_tag_parts = true if v.include?('tag_parts')
+          @has_tag_parts = true if v && v.include?('tag_parts')
           @map[k] = DynamicExpander.new(k, v, @prepare_value)
         end
       end
@@ -167,7 +167,7 @@ DESC
 
     class DynamicExpander
       def initialize(param_key, param_value, prepare_value)
-        if param_value.include?('${')
+        if param_value && param_value.include?('${')
           __str_eval_code__ = parse_parameter(param_value)
 
           # Use class_eval with string instead of define_method for performance.

--- a/lib/fluent/plugin/out_record_modifier.rb
+++ b/lib/fluent/plugin/out_record_modifier.rb
@@ -77,7 +77,7 @@ DESC
       conf.elements.select { |element| element.name == 'record' }.each do |element|
         element.each_pair do |k, v|
           element.has_key?(k) # to suppress unread configuration warning
-          @has_tag_parts = true if v.include?('tag_parts')
+          @has_tag_parts = true if v && v.include?('tag_parts')
           @map[k] = DynamicExpander.new(k, v, @prepare_value)
         end
       end
@@ -198,7 +198,7 @@ DESC
       attr_reader :param_value
 
       def initialize(param_key, param_value, prepare_value)
-        if param_value.include?('${')
+        if param_value && param_value.include?('${')
           __str_eval_code__ = parse_parameter(param_value)
 
           # Use class_eval with string instead of define_method for performance.

--- a/test/test_filter_record_modifier.rb
+++ b/test/test_filter_record_modifier.rb
@@ -226,4 +226,23 @@ CONFIG
       ], d.filtered.map { |e| e.last }
     end
   end
+
+  def test_use_nil
+    require "fluent/version"
+    if Gem::Version.new(Fluent::VERSION) < Gem::Version.new("1.8.0")
+      omit "use_nil is only available in Fluentd 1.8.0 and higher"
+    end
+
+    d = create_driver %q[
+      <record>
+        test_key "#{use_nil}"
+      </record>
+    ]
+
+    d.run(default_tag: @tag) do
+      d.feed("k" => "v")
+    end
+
+    assert_equal [{"k" => "v", "test_key" => nil}], d.filtered.map(&:last)
+  end
 end

--- a/test/test_out_record_modifier.rb
+++ b/test/test_out_record_modifier.rb
@@ -1,6 +1,7 @@
+require 'fluent/test'
 require 'fluent/test/driver/output'
 require 'fluent/plugin/out_record_modifier'
-
+require 'test/unit'
 
 class RecordModifierOutputTest < Test::Unit::TestCase
   def setup
@@ -138,5 +139,25 @@ class RecordModifierOutputTest < Test::Unit::TestCase
     end
 
     assert_equal [{"k1" => 'v', "k2" => 'v', 'foo' => 'bar'}], d.events.map { |e| e.last }
+  end
+
+  def test_use_nil
+    require "fluent/version"
+    if Gem::Version.new(Fluent::VERSION) < Gem::Version.new("1.8.0")
+      omit "use_nil is only available in Fluentd 1.8.0 and higher"
+    end
+
+    d = create_driver %q[
+      tag foo.filtered
+      <record>
+        test_key "#{use_nil}"
+      </record>
+    ]
+
+    d.run(default_tag: "test_tags") do
+      d.feed("k" => "v")
+    end
+
+    assert_equal [{"k" => "v", "test_key" => nil}], d.events.map(&:last)
   end
 end


### PR DESCRIPTION
```
$ cat fluent.conf
<source>
  @type forward
</source>

<filter t1>
  @type record_modifier
  <record>
    c "#{use_nil}"
  </record>
</filter>

<match t1>
  @type record_modifier
  tag t2
  <record>
    d "#{use_nil}"
  </record>
</match>

<match t2>
  @type stdout
</match>

$ echo '{"a":"b"}' | bundle exec fluent-cat t1
```

Before:
```
$ bundle exec fluentd -c fluent.conf
...
2025-08-23 12:26:51 +0900 [error]: unexpected error error_class=NoMethodError error="undefined method `include?' for nil:NilClass"
```

After:
```
$ bundle exec fluentd -c fluent.conf
...
2025-08-23 12:27:17.577618000 +0900 t2: {"a":"b","c":null,"d":null}
```

