### PR TITLE
ci: use ruby-versions to keep up-to-date

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,13 +3,20 @@ on:
   - push
   - pull_request
 jobs:
+  ruby-versions:
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    with:
+      engine: cruby
+      min_version: 3.1
+
   build:
+    needs: ruby-versions
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.1', '3.2', '3.3', '3.4']
+        ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os:
           - ubuntu-latest
         experimental: [false]


### PR DESCRIPTION
Reduce maintainance to keep up-to-date ruby-versions.
