### PR TITLE
ci: drop duplicated ruby: head job

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,6 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
+        exclude:
+          - ruby: head
         os:
           - ubuntu-latest
         experimental: [false]


### PR DESCRIPTION
Follow up #76, ruby-versions contains "head" by default,
so previous actions contain ruby "head" job twice.